### PR TITLE
Add docs for tabular component display

### DIFF
--- a/components/typography/typography.css
+++ b/components/typography/typography.css
@@ -1,0 +1,44 @@
+/*doc
+---
+title: Typography
+name: typography
+category: Base CSS
+---
+
+These are the heading sizes that you can use site wide.
+
+```html_example_table
+<h1>h1 36px</h1>
+
+<h2>h2 25px</h2>
+
+<h3>h3 20px</h3>
+
+<h4>h4 18px</h4>
+
+<h5>h5 16px</h5>
+
+<p>This is an example of our base font style 16px. Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+```
+
+*/
+
+h1{
+  font-size: 36px;
+}
+
+h2{
+  font-size: 25px;
+}
+
+h3{
+  font-size: 20px;
+}
+
+h4{
+  font-size: 18px;
+}
+
+h5{
+  font-size: 16px;
+}

--- a/config.yml
+++ b/config.yml
@@ -18,3 +18,8 @@ documentation_assets: ./templates
 # libraries and any other dependencies your style guide will have
 dependencies:
   - ./build
+
+# To additionally output navigation for top level sections, set the value to
+# 'section'. To output navigation for sub-sections,
+# set the value to `all`
+nav_level: all

--- a/templates/static/css/doc.css
+++ b/templates/static/css/doc.css
@@ -103,6 +103,12 @@ div.codeBlock {
   border-bottom-right-radius: 4px;
 }
 
+table div.codeBlock {
+  background-color: transparent;
+  border-top: none;
+  border-radius: 0;
+}
+
 .docSwatch {
   min-height: 218.21px;
   border: 1px solid #ccc;


### PR DESCRIPTION
Shows how to create `html_example_table`, also works for haml. See https://github.com/trulia/hologram/pull/154 for more detail. It shouldn't break anything (will parse as an unknown language), but it won't work completely until that PR is merged.

@gpleiss & Nicole
