### PR TITLE
Fix anchors links by using headerId instead of headerText

### DIFF
--- a/templates/_footer.html
+++ b/templates/_footer.html
@@ -13,11 +13,12 @@ $(document).ready(function() {
   var $componentList = $('.componentList');
 
   $headers.each(function() {
-    var headerText = $(this).text();
-    $(this).attr('id', headerText);
+    var $this = $(this),
+        headerText = $this.text(),
+        headerId = $this.attr('id');
 
     $componentList.append(
-      '<li><a href="#' + headerText + '">' + headerText + '</a></li>'
+      '<li><a href="' + headerId + '">' + headerText + '</a></li>'
     );
   });
 


### PR DESCRIPTION
anchors links were broken in case of special characters in titles
