### PR TITLE
Fix Line Highlight Style

### DIFF
--- a/templates/static/css/github.css
+++ b/templates/static/css/github.css
@@ -1,4 +1,4 @@
-hll { background-color: #ffffcc }
+.hll { background-color: #ffffcc } /* Highlighted Line */
 .c { color: #999988; font-style: italic } /* Comment */
 .err { color: #a61717; background-color: #e3d2d2 } /* Error */
 .k { color: #000000; font-weight: bold } /* Keyword */


### PR DESCRIPTION
The `.hll` class is missing the leading `.` and a comment explaining the
purpose of the class causing line highlights not to have the desired
appearance.

This commit fixes [the class added by pygments.rb to highlight a line](https://github.com/tmm1/pygments.rb/blob/8849bb16e2016d0515e90570b84eb002d2e6525e/vendor/pygments-main/pygments/formatters/html.py#L808)
within the `github.css` example docs because [the Hologram gem links
directly to the file](https://github.com/trulia/hologram#styling-your-code-examples) which most people using Hologram are likely to copy
for their own syntax highlighting purposes.